### PR TITLE
support systems where uname reports aarch64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -45,6 +45,9 @@ download_release() {
     arm64-linux)
       url="$GH_REPO/releases/download/v${version}/eza_aarch64-unknown-linux-gnu.tar.gz"
       ;;
+    aarch64-linux)
+      url="$GH_REPO/releases/download/v${version}/eza_aarch64-unknown-linux-gnu.tar.gz"
+      ;;
     x86_64-linux)
       url="$GH_REPO/releases/download/v${version}/eza_x86_64-unknown-linux-gnu.tar.gz"
       ;;


### PR DESCRIPTION
On my rpi4, uname reports `aarch64` rather than `arm64`. See below.
This PR supports that, too.

```bash
$ uname -a                             
Linux home 6.1.21-v8+ #1642 SMP PREEMPT Mon Apr  3 17:24:16 BST 2023 aarch64 GNU/Linux
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 12 (bookworm)
Release:	12
Codename:	bookworm
```
