### PR TITLE
Add x86_64 darwin support

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -55,6 +55,9 @@ download_release() {
     arm64-darwin)
       url="$GH_REPO_CBIN/releases/download/eza-${version}/eza-${version}-aarch64-apple-darwin.tar.gz"
       ;;
+    x86_64-darwin)
+      url="$GH_REPO_CBIN/releases/download/eza-${version}/eza-${version}-x86_64-apple-darwin.tar.gz"
+      ;;
     *)
       fail "Could not determine release URL"
       ;;


### PR DESCRIPTION
👋 

It would be nice to add x84_64 support for Intel based Macs such as iMac/iMac Pro.